### PR TITLE
Cursor movement restrictions from screen data

### DIFF
--- a/src/main/java/com/juojo/commands/CreateCommandInstance.java
+++ b/src/main/java/com/juojo/commands/CreateCommandInstance.java
@@ -1,5 +1,6 @@
 package com.juojo.commands;
 
+import com.juojo.screens.Screen;
 import com.juojo.util.Alerts;
 
 public class CreateCommandInstance {
@@ -9,7 +10,7 @@ public class CreateCommandInstance {
 	private String[] args = new String[maxArgs];
 	private String[] inputArray;
 	
-	public CreateCommandInstance(String input) {
+	public CreateCommandInstance(String input, Screen executedFromScreen) {
 		initArray(args);
 		inputArray = null;
 		
@@ -29,7 +30,7 @@ public class CreateCommandInstance {
 			}
 			
 			if (command.equals("q") || command.equals("quit")) new Quit();
-			else if (command.equals("open")) new Open(args);
+			else if (command.equals("open")) new Open(args, executedFromScreen);
 			//else if (command.equals("w") || command.equals("write")) new Write();
 			else Alerts.COMMAND_NOT_FOUND.newAlert();
 		}

--- a/src/main/java/com/juojo/commands/Open.java
+++ b/src/main/java/com/juojo/commands/Open.java
@@ -3,6 +3,7 @@ package com.juojo.commands;
 import java.nio.file.Path;
 
 import com.juojo.screens.Data;
+import com.juojo.screens.Screen;
 
 public class Open extends Command {
 
@@ -10,10 +11,12 @@ public class Open extends Command {
 	private static final String desc = "Open test file.";
 	
 	private String[] args;
+	private Screen executedFromScreen;
 	
-	protected Open(String[] args) {
+	protected Open(String[] args, Screen executedFromScreen) {
 		super(name, desc);
 		this.args = args;
+		this.executedFromScreen = executedFromScreen;
 		
 		executeCommand();
 	}
@@ -28,8 +31,7 @@ public class Open extends Command {
 			path = Path.of(args[0]);
 		}
 		
-		Data data = new Data();
-		data.readPrint(path);
+		executedFromScreen.readPrintData(path);
 	}
 
 }

--- a/src/main/java/com/juojo/screens/Cursor.java
+++ b/src/main/java/com/juojo/screens/Cursor.java
@@ -23,15 +23,24 @@ public class Cursor {
 	public void handleMovementKeys(int charCode, int rowLenght, int amountOfRows) {
 		
 		if (mode != Mode.EX_MODE) {
-			if      (charCode == VK.ARROW_UP.getCode()    && row > 1) row--;
-			else if (charCode == VK.ARROW_DOWN.getCode()  && row < terminalRow && row < amountOfRows) row++;
-			else if (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol && col <= rowLenght) col++;
-			else if (charCode == VK.ARROW_LEFT.getCode()  && col > 1) col--;
+			if (charCode == VK.ARROW_UP.getCode() && row > 1) {
+				row--;
+			} else if (charCode == VK.ARROW_DOWN.getCode() && row < terminalRow) {
+				if (row < amountOfRows) row++;
+			} else if (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol) {
+				if (row == 1 && col <= rowLenght) col++;
+				else if (row != 1 && col < rowLenght) col++;
+			} else if (charCode == VK.ARROW_LEFT.getCode() && col > 1) {
+				col--;
+			}
 			
 			ANSI.moveCursor(row, col); // row, col
 		} else {
-			if      (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol) exCol++;
-			else if (charCode == VK.ARROW_LEFT.getCode()  && col > 1)   exCol--;
+			if (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol) {
+				exCol++;
+			} else if (charCode == VK.ARROW_LEFT.getCode() && col > 1) {
+				exCol--;
+			}
 			
 			ANSI.moveCursorToColumn(exCol);
 		}

--- a/src/main/java/com/juojo/screens/Cursor.java
+++ b/src/main/java/com/juojo/screens/Cursor.java
@@ -9,6 +9,8 @@ public class Cursor {
 	private int row = 1;
 	private int exCol = 1;
 	
+	private int maxCol = 1;
+	
 	private Screen screen;
 	private Mode mode;
 	private int terminalRow, terminalCol;
@@ -25,13 +27,21 @@ public class Cursor {
 		if (mode != Mode.EX_MODE) {
 			if (charCode == VK.ARROW_UP.getCode() && row > 1) {
 				row--;
+				handleColMemory();
 			} else if (charCode == VK.ARROW_DOWN.getCode() && row < terminalRow) {
-				if (row < amountOfRows) row++;
+				if (row < amountOfRows) {
+					row++;
+					handleColMemory();
+				}
 			} else if (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol) {
 				if (row == 1 && col <= rowLenght) col++;
 				else if (row != 1 && col < rowLenght) col++;
+				
+				maxCol = col; // reset maxCol if the column position is changed
 			} else if (charCode == VK.ARROW_LEFT.getCode() && col > 1) {
 				col--;
+				
+				maxCol = col; // reset maxCol if the column position is changed
 			}
 			
 			ANSI.moveCursor(row, col); // row, col
@@ -47,6 +57,21 @@ public class Cursor {
 		
 	}
 	
+	private void handleColMemory() {		
+		// Assign maxCol
+		if (col > maxCol) {
+			maxCol = col;
+		}
+		
+		// Move cursor to maxCol
+		if (maxCol > Data.getRowLenght(row)) {			
+			if (row == 1) col = Data.getRowLenght(row)+1;  // if it's the first line add one more unit
+			else col = Data.getRowLenght(row); 
+		} else {
+			col = maxCol; 
+		}
+	}
+
 	public void updatePosition() {
 		ANSI.moveCursor(this.row, this.col);
 	}

--- a/src/main/java/com/juojo/screens/Cursor.java
+++ b/src/main/java/com/juojo/screens/Cursor.java
@@ -22,26 +22,53 @@ public class Cursor {
 		terminalCol = screen.getTerminalCol();
 	}
 	
+	// ROW LENGHT == DATA.GET ROW LENGHT ??
 	public void handleMovementKeys(int charCode, int rowLenght, int amountOfRows) {
 		
 		if (mode != Mode.EX_MODE) {
 			if (charCode == VK.ARROW_UP.getCode() && row > 1) {
+				// ARROW UP
 				row--;
 				handleColMemory();
 			} else if (charCode == VK.ARROW_DOWN.getCode() && row < terminalRow) {
+				// ARROW DOWN
 				if (row < amountOfRows) {
 					row++;
 					handleColMemory();
 				}
 			} else if (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol) {
-				if (row == 1 && col <= rowLenght) col++;
-				else if (row != 1 && col < rowLenght) col++;
+				// ARROW RIGHT
+				if (row == 1) {
+					if (col == Data.getRowLenght(row)+1 && amountOfRows > row) {
+						row++;
+						col = 1;
+					} else {
+						if (col <= rowLenght) col++;
+					}
+				} else {
+					if (col == Data.getRowLenght(row) && amountOfRows > row) {
+						row++;
+						col = 1;
+					} else {
+						if (col < rowLenght) col++;
+					}
+						
+				}
 				
-				maxCol = col; // reset maxCol if the column position is changed
-			} else if (charCode == VK.ARROW_LEFT.getCode() && col > 1) {
-				col--;
+				// reset maxCol if the column position is changed
+				maxCol = col;
+			} else if (charCode == VK.ARROW_LEFT.getCode()) {
+				// ARROW LEFT
+				if (col == 1 && row != 1) {
+					row--;
+					if (row == 1) col = Data.getRowLenght(row)+1;  // if it's the first line add one more unit
+					else col = Data.getRowLenght(row);
+				} else if (col > 1) { 
+					col--;
+				}
 				
-				maxCol = col; // reset maxCol if the column position is changed
+				// reset maxCol if the column position is changed
+				maxCol = col;
 			}
 			
 			ANSI.moveCursor(row, col); // row, col

--- a/src/main/java/com/juojo/screens/Cursor.java
+++ b/src/main/java/com/juojo/screens/Cursor.java
@@ -20,13 +20,13 @@ public class Cursor {
 		terminalCol = screen.getTerminalCol();
 	}
 	
-	public void handleMovementKeys(int charCode) {
+	public void handleMovementKeys(int charCode, int rowLenght, int amountOfRows) {
 		
 		if (mode != Mode.EX_MODE) {
-			if      (charCode == VK.ARROW_UP.getCode()    && row > 1)   row--;
-			else if (charCode == VK.ARROW_DOWN.getCode()  && row < terminalRow) row++;
-			else if (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol) col++;
-			else if (charCode == VK.ARROW_LEFT.getCode()  && col > 1)   col--;
+			if      (charCode == VK.ARROW_UP.getCode()    && row > 1) row--;
+			else if (charCode == VK.ARROW_DOWN.getCode()  && row < terminalRow && row < amountOfRows) row++;
+			else if (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol && col <= rowLenght) col++;
+			else if (charCode == VK.ARROW_LEFT.getCode()  && col > 1) col--;
 			
 			ANSI.moveCursor(row, col); // row, col
 		} else {

--- a/src/main/java/com/juojo/screens/Data.java
+++ b/src/main/java/com/juojo/screens/Data.java
@@ -116,5 +116,29 @@ public class Data {
 		Screen.cursor.incrementCol(1);
 		Screen.cursor.updatePosition();
 	}
+
+	public int getRowLenght(int row) {
+		int lenght;
+		
+		if (data.isEmpty()) {
+			lenght = 0;
+		} else {
+			lenght = data.get(row-1).length();
+		}
+		
+		return lenght;
+	}
+
+	public int getAmountOfRows() {
+		int amount;
+		
+		if (data.isEmpty()) {
+			amount = 0;
+		} else {
+			amount = data.size();
+		}
+		
+		return amount;
+	}
 	
 }

--- a/src/main/java/com/juojo/screens/Data.java
+++ b/src/main/java/com/juojo/screens/Data.java
@@ -15,7 +15,7 @@ import com.juojo.util.Util;
 
 public class Data {
 
-	private List<String> data;
+	private static List<String> data;
 	private Path path;
 
 	public Data() {
@@ -117,7 +117,7 @@ public class Data {
 		Screen.cursor.updatePosition();
 	}
 
-	public int getRowLenght(int row) {
+	public static int getRowLenght(int row) {
 		int lenght;
 		
 		if (data.isEmpty()) {

--- a/src/main/java/com/juojo/screens/Data.java
+++ b/src/main/java/com/juojo/screens/Data.java
@@ -15,14 +15,14 @@ import com.juojo.util.Util;
 
 public class Data {
 
-	private static List<String> data;
+	private List<String> data;
 	private Path path;
 
-	public Data() {
+	protected Data() {
 		data = new ArrayList<>();
 	}
 	
-	public void readPrint(Path path) {
+	protected void readPrint(Path path) {
 		this.path = path;
 		
 		if (Screen.canHandleFiles()) { 
@@ -42,7 +42,7 @@ public class Data {
 		}
 	}
 
-	public void insert(char key, int row, int col) {
+	protected void insert(char key, int row, int col) {
 		
 		/* 
 		 This is probably the worst possible approach. Every time the user enters a new key this method is called.
@@ -83,7 +83,7 @@ public class Data {
 		updateLine(row-1);
 	}
 	
-	public void write(Path path) {
+	protected void write(Path path) {
 		this.path = path;
 		
 	}
@@ -117,7 +117,7 @@ public class Data {
 		Screen.cursor.updatePosition();
 	}
 
-	public static int getRowLenght(int row) {
+	public int getRowLenght(int row) {
 		int lenght;
 		
 		if (data.isEmpty()) {

--- a/src/main/java/com/juojo/screens/InputViewer.java
+++ b/src/main/java/com/juojo/screens/InputViewer.java
@@ -19,7 +19,7 @@ public class InputViewer extends Screen {
 		
         while (super.getLoop()) {
 			try {
-				handleKey();
+				super.handleKey(0, 0);
 			} catch (IOException e) {
 				Alerts.newCustomAlert("Error", e.toString(), Colors.RED, null);
 				//e.printStackTrace();

--- a/src/main/java/com/juojo/screens/InputViewer.java
+++ b/src/main/java/com/juojo/screens/InputViewer.java
@@ -19,7 +19,7 @@ public class InputViewer extends Screen {
 		
         while (super.getLoop()) {
 			try {
-				super.handleKey(0, 0);
+				super.handleKey();
 			} catch (IOException e) {
 				Alerts.newCustomAlert("Error", e.toString(), Colors.RED, null);
 				//e.printStackTrace();

--- a/src/main/java/com/juojo/screens/Screen.java
+++ b/src/main/java/com/juojo/screens/Screen.java
@@ -38,7 +38,7 @@ public abstract class Screen {
 		cursor.moveSet(1, 1);
 	}
 	
-	protected void handleKey() throws IOException {
+	protected void handleKey(int rowLenght, int amountOfRows) throws IOException {
 		int secondChar = 0, thirdChar = 0;
 		charCode = System.in.read();
 		
@@ -74,7 +74,7 @@ public abstract class Screen {
 		}
 		
 		handleCustomBinds(mode, charCode);
-		cursor.handleMovementKeys(charCode);
+		cursor.handleMovementKeys(charCode, rowLenght, amountOfRows);
 	}
 
 	private void handleCustomBinds(Mode actualMode, int charCode) {

--- a/src/main/java/com/juojo/screens/Screen.java
+++ b/src/main/java/com/juojo/screens/Screen.java
@@ -1,10 +1,12 @@
 package com.juojo.screens;
 
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
 import com.juojo.commands.CreateCommandInstance;
+import com.juojo.screens.cursor.Cursor;
 import com.juojo.util.ANSI;
 import com.juojo.util.Alerts;
 import com.juojo.util.Colors;
@@ -20,6 +22,7 @@ public abstract class Screen {
 	private static boolean canHandleFiles = false;
 	
 	public static Cursor cursor;
+	protected Data data;
 	
 	protected int charCode;
 	
@@ -28,17 +31,19 @@ public abstract class Screen {
 	private List<Integer> charCodeList = new ArrayList<>(); // Array list for commands from EX_MODE
 	private String userInput = "";
 	
-	public Screen(int row, int col, boolean canHandleFiles) {
+	protected Screen(int row, int col, boolean canHandleFiles) {
 		resizeScreen(row, col);
 		this.loop = true;
 		this.canHandleFiles = canHandleFiles;
 		mode = Mode.INSERT_MODE;
 		
+		if (canHandleFiles) data = new Data();
+		
 		cursor = new Cursor(this);
 		ANSI.moveCursorHome();
 	}
 	
-	protected void handleKey(int rowLenght, int amountOfRows) throws IOException {
+	protected void handleKey() throws IOException {
 		int secondChar = 0, thirdChar = 0;
 		charCode = System.in.read();
 		
@@ -74,7 +79,7 @@ public abstract class Screen {
 		}
 		
 		handleCustomBinds(mode, charCode);
-		cursor.handleMovementKeys(charCode, rowLenght, amountOfRows);
+		if (canHandleFiles) cursor.handleMovementKeys(charCode, data);
 	}
 
 	private void handleCustomBinds(Mode actualMode, int charCode) {
@@ -123,7 +128,7 @@ public abstract class Screen {
 					}
 					
 					userInput = charCodeListToString(charCodeList);
-					new CreateCommandInstance(userInput);
+					new CreateCommandInstance(userInput, this);
 					
 					changeMode(Mode.NORMAL_MODE);
 					charCodeList.clear();
@@ -263,6 +268,11 @@ public abstract class Screen {
 
 	public Mode getCurrentMode() {
 		return mode;
+	}
+
+	public void readPrintData(Path path) {
+		data = new Data();
+		data.readPrint(path);
 	}
 	
 	//System.out.println("\033[4;44;31mHola\033[0m");

--- a/src/main/java/com/juojo/screens/Screen.java
+++ b/src/main/java/com/juojo/screens/Screen.java
@@ -35,7 +35,7 @@ public abstract class Screen {
 		mode = Mode.INSERT_MODE;
 		
 		cursor = new Cursor(this);
-		cursor.moveSet(1, 1);
+		ANSI.moveCursorHome();
 	}
 	
 	protected void handleKey(int rowLenght, int amountOfRows) throws IOException {
@@ -102,10 +102,8 @@ public abstract class Screen {
 		}
 		case INSERT_MODE: {
 			
-			if (charCode == 13 || charCode == 10) { // Enter
-				System.out.print("\n");
-				cursor.incrementRow(1);
-				cursor.setCol(0);
+			if (charCode == 13 || charCode == 10) { // Enter);
+				cursor.moveSet(0, cursor.getRow()+1);
 			}
 			
 			break;

--- a/src/main/java/com/juojo/screens/TextViewer.java
+++ b/src/main/java/com/juojo/screens/TextViewer.java
@@ -30,7 +30,7 @@ public class TextViewer extends Screen {
 		
         while (super.getLoop()) {
 			try {
-				super.handleKey();
+				super.handleKey(data.getRowLenght(cursor.getRow()), data.getAmountOfRows());
 			} catch (IOException e) {
 				Alerts.newCustomAlert("Error", e.toString(), Colors.RED, null);
 				//e.printStackTrace();

--- a/src/main/java/com/juojo/screens/TextViewer.java
+++ b/src/main/java/com/juojo/screens/TextViewer.java
@@ -12,7 +12,6 @@ import com.juojo.util.Util;
 public class TextViewer extends Screen {
 	
 	private static boolean canHandleFiles = true;
-	private Data data = new Data();
 	
 	public TextViewer(int row, int col, String[] args) {
 		super(row, col, canHandleFiles);
@@ -23,14 +22,14 @@ public class TextViewer extends Screen {
 		
 		if (args.length != 0) {
 			super.changeMode(Mode.NORMAL_MODE);
-			new CreateCommandInstance("open " + args[0]);
+			new CreateCommandInstance("open " + args[0], this);
 		}
 		
 		ANSI.moveCursorHome();
 		
         while (super.getLoop()) {
 			try {
-				super.handleKey(data.getRowLenght(cursor.getRow()), data.getAmountOfRows());
+				super.handleKey();
 			} catch (IOException e) {
 				Alerts.newCustomAlert("Error", e.toString(), Colors.RED, null);
 				//e.printStackTrace();
@@ -38,7 +37,7 @@ public class TextViewer extends Screen {
 			
 			if (super.charCode >= 0) {
 				if (super.mode == Mode.INSERT_MODE) {
-					data.insert((char) super.charCode, cursor.getRow(), cursor.getCol());
+					super.data.insert((char) super.charCode, cursor.getRow(), cursor.getCol());
 				} else if (super.mode == Mode.EX_MODE) {
 					printChar();
 					cursor.incrementExCol(1);

--- a/src/main/java/com/juojo/screens/cursor/Cursor.java
+++ b/src/main/java/com/juojo/screens/cursor/Cursor.java
@@ -1,5 +1,8 @@
-package com.juojo.screens;
+package com.juojo.screens.cursor;
 
+import com.juojo.screens.Data;
+import com.juojo.screens.Mode;
+import com.juojo.screens.Screen;
 import com.juojo.util.ANSI;
 import com.juojo.virtualkeymapping.VK;
 
@@ -22,35 +25,35 @@ public class Cursor {
 		terminalCol = screen.getTerminalCol();
 	}
 	
-	// ROW LENGHT == DATA.GET ROW LENGHT ??
-	public void handleMovementKeys(int charCode, int rowLenght, int amountOfRows) {
+	public void handleMovementKeys(int charCode, Data data) {
+		int amountOfRows = data.getAmountOfRows();
 		
 		if (mode != Mode.EX_MODE) {
 			if (charCode == VK.ARROW_UP.getCode() && row > 1) {
 				// ARROW UP
 				row--;
-				handleColMemory();
+				handleColMemory(data.getRowLenght(row));
 			} else if (charCode == VK.ARROW_DOWN.getCode() && row < terminalRow) {
 				// ARROW DOWN
 				if (row < amountOfRows) {
 					row++;
-					handleColMemory();
+					handleColMemory(data.getRowLenght(row));
 				}
 			} else if (charCode == VK.ARROW_RIGHT.getCode() && col < terminalCol) {
 				// ARROW RIGHT
 				if (row == 1) {
-					if (col == Data.getRowLenght(row)+1 && amountOfRows > row) {
+					if (col == data.getRowLenght(row)+1 && amountOfRows > row) {
 						row++;
 						col = 1;
 					} else {
-						if (col <= rowLenght) col++;
+						if (col <= data.getRowLenght(row)) col++;
 					}
 				} else {
-					if (col == Data.getRowLenght(row) && amountOfRows > row) {
+					if (col == data.getRowLenght(row) && amountOfRows > row) {
 						row++;
 						col = 1;
 					} else {
-						if (col < rowLenght) col++;
+						if (col < data.getRowLenght(row)) col++;
 					}
 						
 				}
@@ -61,8 +64,8 @@ public class Cursor {
 				// ARROW LEFT
 				if (col == 1 && row != 1) {
 					row--;
-					if (row == 1) col = Data.getRowLenght(row)+1;  // if it's the first line add one more unit
-					else col = Data.getRowLenght(row);
+					if (row == 1) col = data.getRowLenght(row)+1;  // if it's the first line add one more unit
+					else col = data.getRowLenght(row);
 				} else if (col > 1) { 
 					col--;
 				}
@@ -84,16 +87,16 @@ public class Cursor {
 		
 	}
 	
-	private void handleColMemory() {		
+	private void handleColMemory(int rowLenght) {		
 		// Assign maxCol
 		if (col > maxCol) {
 			maxCol = col;
 		}
 		
 		// Move cursor to maxCol
-		if (maxCol > Data.getRowLenght(row)) {			
-			if (row == 1) col = Data.getRowLenght(row)+1;  // if it's the first line add one more unit
-			else col = Data.getRowLenght(row); 
+		if (maxCol > rowLenght) {			
+			if (row == 1) col = rowLenght+1;  // if it's the first line add one more unit
+			else col = rowLenght; 
 		} else {
 			col = maxCol; 
 		}


### PR DESCRIPTION
With this PR now, the cursor only moves through the text on the screen. It also incorporates common case scenarios for text editors, like: Move one line down if the right arrow is pressed at the end of the current line or column memory when changing lines.